### PR TITLE
fix(playbook.yaml & ubuntushell):Fixed the ethO

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -7,7 +7,7 @@
       todays_date: "{{ ansible_facts['date_time']['date'] }}"
       host_name: "{{ ansible_facts['hostname'] }}"
       fqdn_name: "{{ ansible_facts['fqdn'] }}"
-      ip_address: "{{ ansible_facts['eth0']['ipv4']['address'] }}"
+      ip_address: "{{ ansible_facts['default_ipv4']['address'] }}"
     tasks:
        - name: Run Apt Update
          shell: apt update && apt install -y python3-apt

--- a/ubuntushellscript
+++ b/ubuntushellscript
@@ -14,7 +14,7 @@ sudo git clone https://github.com/saikiranpi/autoscaling_testing.git /myrepo
 ######GIVE ONLY ABOVE IN THE USER DATA FOR AMI IMAGE FOR AWS AUTOSCALING##########
 #
 #####GIVE BELOW IN THE LAUNCH CONFIG USERDATA#####################################
-ansible-playbook /myrepo/playbook.yaml
+sudo ansible-playbook /myrepo/playbook.yaml
 
 ######GIVE BELOW IN THE CUSTOM DATA OF AZURE VMSSS################################
 #cloud-config


### PR DESCRIPTION
After running ansible-playbook /myrepo/playbook.yaml

I was facing this error 

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: {{ ansible_facts['eth0']['ipv4']['address'] }}: 'dict object' has no attribute 'eth0'
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: {{ ansible_facts['eth0']['ipv4']['address'] }}: 'dict object' has no attribute 'eth0'"}

I have added the fix for the repository, so anyone pulling this repo doesn't face a similar issue. 